### PR TITLE
Creating the Errors Only debug mode

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -127,7 +127,10 @@ logger.addHandler(logfile_handler)
 # NOTE: This is the addon's own logger. Use it to log messages on different levels.
 # create logger
 LookingGlassAddonLogger = logging.getLogger('Alice/LG')
-LookingGlassAddonLogger.setLevel(logging.DEBUG)
+if LookingGlassAddon.debugging_print_internal_logger_all:
+	LookingGlassAddonLogger.setLevel(logging.DEBUG)
+else:
+	LookingGlassAddonLogger.setLevel(logging.ERROR)
 
 # create console handler and set level to WARNING
 console_handler = logging.StreamHandler()
@@ -185,15 +188,11 @@ LookingGlassAddonLogger.info(" [#] Add-on path: %s" % LookingGlassAddon.path)
 if bpy.app.version < bl_info['blender']:
 	raise Exception("This version of Blender is not supported by " + bl_info['name'] + ". Please use v" + '.'.join(str(v) for v in bl_info['blender']) + " or higher.")
 
-# Check Add-on Dependencies
-# +++++++++++++++++++++++++++++++++++++++++++++
-# this to produce log messages
-LookingGlassAddon.check_dependecies(debug=True)
 
 # Load Internal Modules
 # +++++++++++++++++++++++++++++++++++++++++++++
-# if NOT all the dependenceis are satisfied
-if not LookingGlassAddon.check_dependecies():
+# if NOT all the dependenceis are satisfied, debug will produce log messages.
+if not LookingGlassAddon.check_dependecies(debug=LookingGlassAddon.debugging_print_internal_logger_all):
 
 	# reload/import all preferences' related code
 	try:

--- a/__init__.py
+++ b/__init__.py
@@ -61,8 +61,8 @@ LookingGlassAddon.debugging_use_dummy_device = False
 # console output: if set to true, the Alice/LG and pyLightIO logger messages
 # of all levels are printed to the console. If set to falls, only warnings and
 # errors are printed to console.
-LookingGlassAddon.debugging_print_pylio_logger_all = True
-LookingGlassAddon.debugging_print_internal_logger_all = True
+LookingGlassAddon.debugging_print_pylio_logger_all = False
+LookingGlassAddon.debugging_print_internal_logger_all = False
 
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -127,10 +127,7 @@ logger.addHandler(logfile_handler)
 # NOTE: This is the addon's own logger. Use it to log messages on different levels.
 # create logger
 LookingGlassAddonLogger = logging.getLogger('Alice/LG')
-if LookingGlassAddon.debugging_print_internal_logger_all:
-	LookingGlassAddonLogger.setLevel(logging.DEBUG)
-else:
-	LookingGlassAddonLogger.setLevel(logging.ERROR)
+LookingGlassAddonLogger.setLevel(logging.DEBUG)
 
 # create console handler and set level to WARNING
 console_handler = logging.StreamHandler()

--- a/globals.py
+++ b/globals.py
@@ -246,6 +246,15 @@ class LookingGlassAddon:
 				# if the level is ERROR
 				elif bpy.context.preferences.addons[__package__].preferences.logger_level == '2':
 					handler.setLevel(logging.ERROR)
+
+
+	@staticmethod
+	def update_console_output(self, context):
+		'''Update the global vars controlling outputs to console'''
+		LookingGlassAddon.debugging_print_pylio_logger_all = self.console_output
+		LookingGlassAddon.debugging_print_internal_logger_all = self.console_output
+
+
 	# update the lightfield window to display a lightfield on the device
 	@staticmethod
 	def update_lightfield_window(render_mode, lightfield_image, flip_views=None, invert=None):

--- a/globals.py
+++ b/globals.py
@@ -224,6 +224,10 @@ class LookingGlassAddon:
 				elif bpy.context.preferences.addons[__package__].preferences.logger_level == '1':
 					handler.setLevel(logging.INFO)
 
+				# if the level is ERROR
+				elif bpy.context.preferences.addons[__package__].preferences.logger_level == '2':
+					handler.setLevel(logging.ERROR)
+
 		# 2: Alice/LG logger
 		logger = logging.getLogger('Alice/LG')
 		for handler in logger.handlers:
@@ -238,6 +242,15 @@ class LookingGlassAddon:
 				# if the level is INFO
 				elif bpy.context.preferences.addons[__package__].preferences.logger_level == '1':
 					handler.setLevel(logging.INFO)
+
+				# if the level is ERROR
+				elif bpy.context.preferences.addons[__package__].preferences.logger_level == '2':
+					handler.setLevel(logging.ERROR)
+
+		# 3. Enable or disable all logging mode.
+		enable = bpy.context.preferences.addons[__package__].preferences.logger_level != '2'
+		LookingGlassAddon.debugging_print_pylio_logger_all = enable
+		LookingGlassAddon.debugging_print_internal_logger_all = enable
 
 	# update the lightfield window to display a lightfield on the device
 	@staticmethod

--- a/globals.py
+++ b/globals.py
@@ -246,12 +246,6 @@ class LookingGlassAddon:
 				# if the level is ERROR
 				elif bpy.context.preferences.addons[__package__].preferences.logger_level == '2':
 					handler.setLevel(logging.ERROR)
-
-		# 3. Enable or disable all logging mode.
-		enable = bpy.context.preferences.addons[__package__].preferences.logger_level != '2'
-		LookingGlassAddon.debugging_print_pylio_logger_all = enable
-		LookingGlassAddon.debugging_print_internal_logger_all = enable
-
 	# update the lightfield window to display a lightfield on the device
 	@staticmethod
 	def update_lightfield_window(render_mode, lightfield_image, flip_views=None, invert=None):

--- a/preferences.py
+++ b/preferences.py
@@ -154,15 +154,16 @@ class LOOKINGGLASS_PT_preferences(AddonPreferences):
 									name="Logging Mode",
 									update=LookingGlassAddon.update_logger_levels,
 									)
+	console_output: bpy.props.BoolProperty(
+									default=False,
+									name="Log to console",
+									description="Additionally log outputs to std out for debugging",
+									update=LookingGlassAddon.update_console_output,
+									)
+
 	# draw function
 	def draw(self, context):
-
 		layout = self.layout
-
-		# render mode
-		row_render_mode = layout.row()
-		row_render_mode.prop(self, "render_mode")
-
-		# logger level
-		row_logger_level = layout.row()
-		row_logger_level.prop(self, "logger_level")
+		layout.prop(self, "render_mode")
+		layout.prop(self, "logger_level")
+		layout.prop(self, "console_output")

--- a/preferences.py
+++ b/preferences.py
@@ -147,8 +147,9 @@ class LOOKINGGLASS_PT_preferences(AddonPreferences):
 
 	# logger level
 	logger_level: bpy.props.EnumProperty(
-									items = [('0', 'Debug messages', 'All messages are written to the log file. This is for detailed debugging and extended bug reports.'),
-											 ('1', 'Info, Warnings, and Errors', 'All info, warning, and error messages are written to the log file. This is for standard bug reports.')],
+									items = [('0', 'Debug messages', 'All messages are written to the log file. This is for detailed debugging and extended bug reports'),
+											 ('1', 'Info, Warnings, and Errors', 'All info, warning, and error messages are written to the log file. This is for standard bug reports'),
+											 ('2', 'Only Errors', 'Only error messages are written to the log file. This is for less verbose console outputs')],
 									default='1',
 									name="Logging Mode",
 									update=LookingGlassAddon.update_logger_levels,

--- a/preferences.py
+++ b/preferences.py
@@ -164,6 +164,23 @@ class LOOKINGGLASS_PT_preferences(AddonPreferences):
 	# draw function
 	def draw(self, context):
 		layout = self.layout
-		layout.prop(self, "render_mode")
-		layout.prop(self, "logger_level")
-		layout.prop(self, "console_output")
+# render mode
+row_render_mode = layout.row()
+column_1 = row_render_mode.column()
+column_1.label(text="Render Mode:")
+column_1.scale_x = 0.2
+column_2 = row_render_mode.column()
+column_2.prop(self, "render_mode", text="")
+column_2.scale_x = 0.8
+
+# logger level
+row_logger = layout.row()
+column_1 = row_logger.column()
+column_1.label(text="Logging Mode:")
+column_1.scale_x = 0.2
+column_2 = row_logger.column()
+column_2.prop(self, "logger_level", text="")
+column_2.scale_x = 0.55
+column_3 = row_logger.column()
+column_3.prop(self, "console_output")
+column_3.scale_x = 0.25


### PR DESCRIPTION
Note: This will only take effect on logs after the addon registration has completed, some logging statements come from the moment of imports before addon preferences have registered.

More work could potentially be done to restructure the way that dependencies are loaded so that they:

1) Don't hang blender on startup: first time loading blender after dependencies are pip installed takes an extra moment before blender's UI appears).
2) Minimize additional printouts on blender startup.

I wouldn't say it's critical, but I'm happy to explore. Would likely require deferred importing or otherwise caching the logging setting in a persistent way.