### PR TITLE
Enforce individual file output for multi-view

### DIFF
--- a/lightfield_render.py
+++ b/lightfield_render.py
@@ -347,6 +347,7 @@ class RenderJob:
 
 				# set to view format to
 				self.scene.render.views_format = 'MULTIVIEW'
+				self.scene.render.image_settings.views_format = "INDIVIDUAL"
 
 				# deactivate 'left' and 'right' view
 				self.scene.render.views['left'].use = False


### PR DESCRIPTION
Multi-view render does not save renders properly when views_format is set to STEREO_3D output. This is best enforced to "INDIVIDUAL" to prevent conflicts with existing projects.