### PR TITLE
Adding functionality for Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Alice/LG 2.2 - The Blender Add-on for Looking Glass Displays
+# Alice/LG 2.3 - The Blender Add-on for Looking Glass Displays
 
 ### Let [Alice/LG](https://github.com/regcs/AliceLG/releases) take your Blender artworks through the Looking Glass! This short guide is to get you started.
 
@@ -13,7 +13,7 @@ This add-on was created for the use of Blender with the Looking Glass holographi
 - decide if you want to keep the separate view files or just the final quilt
 - support for multiple scenes and view layers
 - camera & quilt settings are saved with your Blender file
-- support for all available Looking Glass displays (including the new Looking Glass Portrait)
+- support for all available Looking Glass displays (including the new Looking Glass Go)
 - _Experimental feature:_ Detect incomplete render jobs (see below for details)
 
 ## System Requirements

--- a/__init__.py
+++ b/__init__.py
@@ -21,7 +21,7 @@
 bl_info = {
 	"name": "Alice/LG",
 	"author": "Christian Stolze",
-	"version": (2, 2, 2),
+	"version": (2, 3, 0),
 	"blender": (2, 93, 6),
 	"location": "View3D > Looking Glass Tab",
 	"description": "Alice/LG takes your artworks through the Looking Glass (lightfield displays)",

--- a/__init__.py
+++ b/__init__.py
@@ -294,9 +294,9 @@ def LookingGlassAddonInitHandler(dummy1, dummy2):
 			elif not (device and preset):
 
 				# fallback solution, if the default quilt is not found:
-				# We use the Looking Glass Portrait standard quilt (48 views)
-				bpy.context.scene.addon_settings.quiltPreset = "4"
-				bpy.context.scene.addon_settings.render_quilt_preset = "4"
+				# We use the Looking Glass Go standard quilt (48 views)
+				bpy.context.scene.addon_settings.quiltPreset = "5"
+				bpy.context.scene.addon_settings.render_quilt_preset = "5"
 
 		# check if Blender is run in background mode
 		if LookingGlassAddon.background:

--- a/lib/pylightio/lookingglass/devices.py
+++ b/lib/pylightio/lookingglass/devices.py
@@ -244,6 +244,47 @@ class LookingGlassDeviceMixin(object):
 
 # SPECIFIC LOOKING GLASS DEVICE TYPES
 ###############################################
+# Looking Glass Go
+class LookingGlassGo(LookingGlassDeviceMixin, BaseDeviceType):
+
+    # PUBLIC MEMBERS
+    # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    type = "go_p"                # the unique identifier string of this device type
+    name = "Looking Glass Go"  # name of this device type
+    formats = [LookingGlassQuilt]    # list of lightfield image formats that are supported
+    emulated_configuration = {       # configuration used for emulated devices of this type
+                'buttons': [0, 0, 0, 0],
+                'calibration': {
+                                    'DPI': 491.0,
+                                    'configVersion': '1.0',
+                                    'screenH': 2560.0,
+                                    'screenW': 1440.0,
+                                    'serial': 'LKG-EDUMMY',
+                                    'viewCone': 40.0,
+                                    'aspect': 0.5625,
+                                    'invView': True
+                                },
+                'defaultQuilt': {
+                                    'quiltAspect': 0.5625,
+                                    'quiltX': 4092,
+                                    'quiltY': 4092,
+                                    'tileX': 11,
+                                    'tileY': 6
+                                },
+                'hardwareVersion': 'go_p',
+                'hwid': 'LKG0009DUMMY',
+                'index': 0,
+                'joystickIndex': -1,
+                'state': 'ok',
+            }
+
+
+    # INSTANCE METHODS
+    # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    # NOTE: Here is the place to define methods required by the BaseClass for any
+    #       device type implementations
+
+    # This type uses the LookingGlassBaseType and has no special requirements
 
 # Looking Glass Portrait
 class LookingGlassPortrait(LookingGlassDeviceMixin, BaseDeviceType):
@@ -286,6 +327,7 @@ class LookingGlassPortrait(LookingGlassDeviceMixin, BaseDeviceType):
     #       device type implementations
 
     # This type uses the LookingGlassBaseType and has no special requirements
+
 # 4K Gen2: 4K Gen2 Looking Glass
 class LookingGlass4kGen2(LookingGlassDeviceMixin, BaseDeviceType):
 

--- a/lib/pylightio/lookingglass/lightfields.py
+++ b/lib/pylightio/lookingglass/lightfields.py
@@ -64,6 +64,8 @@ class LookingGlassQuilt(BaseLightfieldImageFormat):
             #Looking Glass Portrait
             4: {'description': "Portrait, 48 Views", 'quilt_width': 3360, 'quilt_height': 3360, 'view_width': 420, 'view_height': 560, 'columns': 8, 'rows': 6, 'total_views': 48, 'hidden': False },
 
+            # third gen devices
+            5: {'description': "Go, 66 Views", 'quilt_width': 4092, 'quilt_height': 4092, 'view_width': 372, 'view_height': 682, 'columns': 11, 'rows': 6, 'total_views': 66, 'hidden': False },
         }
 
         @classmethod

--- a/preferences.py
+++ b/preferences.py
@@ -137,7 +137,7 @@ class LOOKINGGLASS_PT_install_dependencies(AddonPreferences):
 			row = layout.row(align=True)
 			row.alignment = 'EXPAND'
 			row.scale_y = 0.5
-			row.label(text="required to communicate with HoloPlay Service. If you click the button below,")
+			row.label(text="required to communicate with Looking Glass Bridge. If you click the button below,")
 			row = layout.row(align=True)
 			row.alignment = 'EXPAND'
 			row.scale_y = 0.5

--- a/ui.py
+++ b/ui.py
@@ -276,9 +276,9 @@ class LookingGlassAddonUI:
 				elif not device or not preset:
 
 					# fallback solution, if the default quilt is not found:
-					# We use the Looking Glass Portrait standard quilt (48 views)
-					if bpy.context.scene.addon_settings.render_quilt_preset != "4":
-						bpy.context.scene.addon_settings.render_quilt_preset = "4"
+					# We use the Looking Glass Go standard quilt (48 views)
+					if bpy.context.scene.addon_settings.render_quilt_preset != "5":
+						bpy.context.scene.addon_settings.render_quilt_preset = "5"
 
 		return None
 
@@ -1322,9 +1322,9 @@ class LOOKINGGLASS_OT_refresh_display_list(bpy.types.Operator):
 					context.scene.addon_settings.quiltPreset = str(preset)
 
 				# fallback solution, if the default quilt is not found:
-				# We use the Looking Glass Portrait standard quilt (48 views)
+				# We use the Looking Glass Go standard quilt (48 views)
 				else:
-					context.scene.addon_settings.quiltPreset = "4"
+					context.scene.addon_settings.quiltPreset = "5"
 
 		return {'FINISHED'}
 


### PR DESCRIPTION
This branch adds support for the new Go device, the first of the Looking Glass Gen3 hardware line-up. The following changes have been made:
- Added Go device under pylightio/lookingglass/devices.py and set the index to be 0, so it is at the top of the list
- Added quilt preset for the Go under lightfields.py
- Updated preferences.py to refer to Bridge instead of Service
- Updated Readme to highlight Go support and have a version of 2.3 instead of 2.2

**Not done**:
- The Go device doesn't currently default to the Go quilt preset - not sure how to configure this @regcs 
- ~~Add-on version when imported reads as 2.2.2 - should probably be 2.3.0, but not sure how to configure this either~~