### PR TITLE
Add string cache for EnumProperty to avoid UnicodeDecodeError.

### DIFF
--- a/globals.py
+++ b/globals.py
@@ -330,17 +330,17 @@ class LookingGlassAddon:
 			else:
 				LookingGlassAddonLogger.error("Could not update the lightfield window. No LightfieldImage was given.")
 
-# STRING CACHE
-##################################################################	
-# see: https://blender.stackexchange.com/questions/299978/how-to-fix-unicodedecodeerror
-_alicelg_string_cache = {}
-def intern_enum_items(items):
-	def intern_string(s):
-		if not isinstance(s, str):
-			return s
-		global _alicelg_string_cache
-		if s not in _alicelg_string_cache:
-			_alicelg_string_cache[s] = s
-			print(len(_alicelg_string_cache))
-		return _alicelg_string_cache[s]
-	return [tuple(intern_string(s) for s in item) for item in items]
+	# STRING CACHE
+	##################################################################	
+	# see: https://blender.stackexchange.com/questions/299978/how-to-fix-unicodedecodeerror
+	_alicelg_string_cache = {}
+	@classmethod
+	def intern_enum_items(cls, items):
+		def intern_string(s):
+			if not isinstance(s, str):
+				return s
+			# global _alicelg_string_cache
+			if s not in cls._alicelg_string_cache:
+				cls._alicelg_string_cache[s] = s
+			return cls._alicelg_string_cache[s]
+		return [tuple(intern_string(s) for s in item) for item in items]

--- a/globals.py
+++ b/globals.py
@@ -330,17 +330,25 @@ class LookingGlassAddon:
 			else:
 				LookingGlassAddonLogger.error("Could not update the lightfield window. No LightfieldImage was given.")
 
-	# STRING CACHE
-	##################################################################	
+
+	# Internal string cache as workaround for UnicodeDecodeError reported in issue #114
 	# see: https://blender.stackexchange.com/questions/299978/how-to-fix-unicodedecodeerror
-	_alicelg_string_cache = {}
+	#
+	# NOTE: https://blender.stackexchange.com/a/245145
+	# 		"The downside is the strings in STRING_CACHE will never be GCed (sort of the opposite of the original problem).
+	# 		 For most people though, I doubt the cache will grow large enough for it to become an issue."
+	_enum_string_cache = {}
+
 	@classmethod
-	def intern_enum_items(cls, items):
+	def enum_string_cache_items(cls, items):
 		def intern_string(s):
+
 			if not isinstance(s, str):
 				return s
-			# global _alicelg_string_cache
-			if s not in cls._alicelg_string_cache:
-				cls._alicelg_string_cache[s] = s
-			return cls._alicelg_string_cache[s]
+			
+			if s not in cls._enum_string_cache:
+				cls._enum_string_cache[s] = s
+
+			return cls._enum_string_cache[s]
+		
 		return [tuple(intern_string(s) for s in item) for item in items]

--- a/globals.py
+++ b/globals.py
@@ -329,3 +329,18 @@ class LookingGlassAddon:
 
 			else:
 				LookingGlassAddonLogger.error("Could not update the lightfield window. No LightfieldImage was given.")
+
+# STRING CACHE
+##################################################################	
+# see: https://blender.stackexchange.com/questions/299978/how-to-fix-unicodedecodeerror
+_alicelg_string_cache = {}
+def intern_enum_items(items):
+	def intern_string(s):
+		if not isinstance(s, str):
+			return s
+		global _alicelg_string_cache
+		if s not in _alicelg_string_cache:
+			_alicelg_string_cache[s] = s
+			print(len(_alicelg_string_cache))
+		return _alicelg_string_cache[s]
+	return [tuple(intern_string(s) for s in item) for item in items]

--- a/ui.py
+++ b/ui.py
@@ -49,6 +49,7 @@ import logging
 LookingGlassAddonLogger = logging.getLogger('Alice/LG')
 
 
+
 # ------------- Add-on UI -------------
 # Class that contains all functions relevant for the UI
 class LookingGlassAddonUI:

--- a/ui.py
+++ b/ui.py
@@ -48,20 +48,6 @@ import pylightio as pylio
 import logging
 LookingGlassAddonLogger = logging.getLogger('Alice/LG')
 
-# ---------------- STRING CACHE --------------------------
-# see: https://blender.stackexchange.com/questions/299978/how-to-fix-unicodedecodeerror
-_alicelg_string_cache = {}
-def intern_enum_items(items):
-	def intern_string(s):
-		if not isinstance(s, str):
-			return s
-		global _alicelg_string_cache
-		if s not in _alicelg_string_cache:
-			_alicelg_string_cache[s] = s
-			print(len(_alicelg_string_cache))
-			# print(s)
-		return _alicelg_string_cache[s]
-	return [tuple(intern_string(s) for s in item) for item in items]
 
 # ------------- Add-on UI -------------
 # Class that contains all functions relevant for the UI
@@ -457,7 +443,6 @@ class LookingGlassAddonUI:
 
 	# Application handler that continously checks for changes of the depsgraph
 	def synchronize_active_camera(scene, depsgraph):
-		print(type(scene).__name__)
 
 		# if the active camera changed AND the active camera is not the "_quilt_render_cam"
 		if scene.addon_settings.lookingglassCamera != scene.camera and scene.camera.name != "_quilt_render_cam":

--- a/ui.py
+++ b/ui.py
@@ -48,7 +48,20 @@ import pylightio as pylio
 import logging
 LookingGlassAddonLogger = logging.getLogger('Alice/LG')
 
-
+# ---------------- STRING CACHE --------------------------
+# see: https://blender.stackexchange.com/questions/299978/how-to-fix-unicodedecodeerror
+_alicelg_string_cache = {}
+def intern_enum_items(items):
+	def intern_string(s):
+		if not isinstance(s, str):
+			return s
+		global _alicelg_string_cache
+		if s not in _alicelg_string_cache:
+			_alicelg_string_cache[s] = s
+			print(len(_alicelg_string_cache))
+			# print(s)
+		return _alicelg_string_cache[s]
+	return [tuple(intern_string(s) for s in item) for item in items]
 
 # ------------- Add-on UI -------------
 # Class that contains all functions relevant for the UI
@@ -92,7 +105,7 @@ class LookingGlassAddonUI:
 
 
 		# return the item list
-		return items
+		return intern_enum_items(items)
 
 
 	# This callback is required to be able to update the list of emulated Looking Glass devices
@@ -121,7 +134,7 @@ class LookingGlassAddonUI:
 
 
 		# return the item list
-		return items
+		return intern_enum_items(items)
 
 	# This callback is required to be able to update the list of presets
 	def quilt_preset_list_callback(self, context):
@@ -140,7 +153,7 @@ class LookingGlassAddonUI:
 
 
 		# return the item list
-		return items
+		return intern_enum_items(items)
 
 	# poll function for the Looking Glass camera selection
 	# this prevents that an object is picked or listed, which is no camera
@@ -444,6 +457,7 @@ class LookingGlassAddonUI:
 
 	# Application handler that continously checks for changes of the depsgraph
 	def synchronize_active_camera(scene, depsgraph):
+		print(type(scene).__name__)
 
 		# if the active camera changed AND the active camera is not the "_quilt_render_cam"
 		if scene.addon_settings.lookingglassCamera != scene.camera and scene.camera.name != "_quilt_render_cam":
@@ -631,7 +645,7 @@ class LookingGlassAddonUI:
 			items.append((workspace, workspace, 'The workspace the desired viewport is found.'))
 
 		# return the item list
-		return items
+		return intern_enum_items(items)
 
 
 
@@ -660,7 +674,7 @@ class LookingGlassAddonUI:
 			items.append(('None', 'None', 'The Blender viewport to which the Looking Glass adjusts'))
 
 		# return the item list
-		return items
+		return intern_enum_items(items)
 
 
 

--- a/ui.py
+++ b/ui.py
@@ -92,7 +92,7 @@ class LookingGlassAddonUI:
 
 
 		# return the item list
-		return intern_enum_items(items)
+		return LookingGlassAddon.intern_enum_items(items)
 
 
 	# This callback is required to be able to update the list of emulated Looking Glass devices
@@ -121,7 +121,7 @@ class LookingGlassAddonUI:
 
 
 		# return the item list
-		return intern_enum_items(items)
+		return LookingGlassAddon.intern_enum_items(items)
 
 	# This callback is required to be able to update the list of presets
 	def quilt_preset_list_callback(self, context):
@@ -140,7 +140,7 @@ class LookingGlassAddonUI:
 
 
 		# return the item list
-		return intern_enum_items(items)
+		return LookingGlassAddon.intern_enum_items(items)
 
 	# poll function for the Looking Glass camera selection
 	# this prevents that an object is picked or listed, which is no camera
@@ -631,7 +631,7 @@ class LookingGlassAddonUI:
 			items.append((workspace, workspace, 'The workspace the desired viewport is found.'))
 
 		# return the item list
-		return intern_enum_items(items)
+		return LookingGlassAddon.intern_enum_items(items)
 
 
 
@@ -660,7 +660,7 @@ class LookingGlassAddonUI:
 			items.append(('None', 'None', 'The Blender viewport to which the Looking Glass adjusts'))
 
 		# return the item list
-		return intern_enum_items(items)
+		return LookingGlassAddon.intern_enum_items(items)
 
 
 

--- a/ui.py
+++ b/ui.py
@@ -92,7 +92,7 @@ class LookingGlassAddonUI:
 
 
 		# return the item list
-		return LookingGlassAddon.intern_enum_items(items)
+		return LookingGlassAddon.enum_string_cache_items(items)
 
 
 	# This callback is required to be able to update the list of emulated Looking Glass devices
@@ -121,7 +121,7 @@ class LookingGlassAddonUI:
 
 
 		# return the item list
-		return LookingGlassAddon.intern_enum_items(items)
+		return LookingGlassAddon.enum_string_cache_items(items)
 
 	# This callback is required to be able to update the list of presets
 	def quilt_preset_list_callback(self, context):
@@ -140,7 +140,7 @@ class LookingGlassAddonUI:
 
 
 		# return the item list
-		return LookingGlassAddon.intern_enum_items(items)
+		return LookingGlassAddon.enum_string_cache_items(items)
 
 	# poll function for the Looking Glass camera selection
 	# this prevents that an object is picked or listed, which is no camera
@@ -631,7 +631,7 @@ class LookingGlassAddonUI:
 			items.append((workspace, workspace, 'The workspace the desired viewport is found.'))
 
 		# return the item list
-		return LookingGlassAddon.intern_enum_items(items)
+		return LookingGlassAddon.enum_string_cache_items(items)
 
 
 
@@ -660,7 +660,7 @@ class LookingGlassAddonUI:
 			items.append(('None', 'None', 'The Blender viewport to which the Looking Glass adjusts'))
 
 		# return the item list
-		return LookingGlassAddon.intern_enum_items(items)
+		return LookingGlassAddon.enum_string_cache_items(items)
 
 
 


### PR DESCRIPTION
According to stackexchange posts([1](https://blender.stackexchange.com/questions/299978/how-to-fix-unicodedecodeerror), [2](https://blender.stackexchange.com/questions/216230/is-there-a-workaround-for-the-known-bug-in-dynamic-enumproperty/245145#245145)),  [`bpy.props.EnumProperty`](https://docs.blender.org/api/current/bpy.props.html#bpy.props.EnumProperty) needs to reference to the strings which returned by callback.

This PR implements a string cache to avoid UnicodeDecodeError and resolves #114.