### PR TITLE
Fix wrong 16in Landscape (Gen3) quilt geometry (49 views, square)

### DIFF
--- a/lib/pylightio/lookingglass/devices.py
+++ b/lib/pylightio/lookingglass/devices.py
@@ -350,10 +350,10 @@ class LookingGlass16Landscape(LookingGlassDeviceMixin, BaseDeviceType):
                                 },
                 'defaultQuilt': {
                                     'quiltAspect': 1.77777777,
-                                    'quiltX': 5999,
-                                    'quiltY': 5999,
-                                    'tileX': 7,
-                                    'tileY': 7
+                                    'quiltX': 7680,
+                                    'quiltY': 4320,
+                                    'tileX': 8,
+                                    'tileY': 6
                                 },
                 'hardwareVersion': '16_gen3_l',
                 'hwid': 'LKG0010DUMMY',

--- a/lib/pylightio/lookingglass/lightfields.py
+++ b/lib/pylightio/lookingglass/lightfields.py
@@ -66,7 +66,7 @@ class LookingGlassQuilt(BaseLightfieldImageFormat):
 
             # third gen devices
             5: {'description': "Go, 66 Views", 'quilt_width': 4092, 'quilt_height': 4092, 'view_width': 372, 'view_height': 682, 'columns': 11, 'rows': 6, 'total_views': 66, 'hidden': False },
-            6: {'description': "16 Landscape, 49 Views", 'quilt_width': 5999, 'quilt_height': 5999, 'view_width': 857, 'view_height': 857, 'columns': 7, 'rows': 7, 'total_views': 49, 'hidden': False },
+            6: {'description': "16 Landscape, 48 Views", 'quilt_width': 7680, 'quilt_height': 4320, 'view_width': 960, 'view_height': 720, 'columns': 8, 'rows': 6, 'total_views': 48, 'hidden': False },
             7: {'description': "16 Portrait, 66 Views", 'quilt_width': 5995, 'quilt_height': 6000, 'view_width': 545, 'view_height': 1000, 'columns': 11, 'rows': 6, 'total_views': 66, 'hidden': False },
             8: {'description': "32 Landscape, 49 Views", 'quilt_width': 8190, 'quilt_height': 8190, 'view_width': 1170, 'view_height': 1170, 'columns': 7, 'rows': 7, 'total_views': 49, 'hidden': False },
             9: {'description': "32 Portrait, 66 Views", 'quilt_width': 8184, 'quilt_height': 8184, 'view_width': 744, 'view_height': 1364, 'columns': 11, 'rows': 6, 'total_views': 66, 'hidden': False },


### PR DESCRIPTION
## Summary

- `16 Landscape` quilt geometry was wrong in both the format catalog (`lightfields.py`) and the emulated device's `defaultQuilt` (`devices.py`): a 5999x5999 square quilt, 7x7 grid, 49 views.
- That's identical to the `32 Landscape` entry right below it, and contradicts the `1.77777777` (16:9) `aspect` declared in the same `emulated_configuration` dict a few lines above.
- Verified against a real Looking Glass 16" Landscape (Gen3), connected via Bridge: its live `defaultQuilt` reports `7680x4320`, 6 rows x 8 columns (48 views).
- Fixed both locations to `7680x4320`, 8 columns x 6 rows, 48 views, matching the live device.

With "Use Device Settings" enabled, `lightfield_render.py` pulls settings from the live connected device and isn't affected by this bug. It bites when a user unchecks that option and manually selects "16 Landscape" from the Resolution dropdown, or when using the emulated 16" Landscape device without hardware connected — both cases render a mismatched 7x7 quilt for a device that actually wants 8x6.

## Test plan

- [x] Queried a connected Looking Glass 16" Landscape (Gen3) via Bridge (`pylio.DeviceManager.get_active()`) — live `defaultQuilt` is `7680x4320`, 6 rows x 8 columns, confirming the corrected values.
- [x] Reloaded the patched add-on in Blender headless and confirmed `pylio.LookingGlassQuilt.formats.get()[6]` now returns the corrected `48 Views` / `8x6` / `7680x4320` entry.
- [ ] Not yet tested: rendering with "Use Device Settings" unchecked and "16 Landscape" manually selected from the Resolution dropdown (the actual code path this catalog entry feeds). Our own rendering used "Use Device Settings" checked, which reads the live device instead and isn't affected by this bug either way — so that path wasn't exercised.
